### PR TITLE
Add style for textarea to preserve linebreaks

### DIFF
--- a/src/pdf/formTemplate.ts
+++ b/src/pdf/formTemplate.ts
@@ -2,7 +2,6 @@ const template = `<!doctype html>
 <html lang="en">
 
 <style type="text/css" media="print">
-     .govuk-textarea,
      .govuk-input,
      .govuk-select,
      .govuk-checkboxes_item,
@@ -14,6 +13,9 @@ const template = `<!doctype html>
     body {
       overscroll-behavior-y: none;
       font-family: "nta", Arial, sans-serif;
+     }
+     .govuk-textarea div {
+        white-space: pre-wrap;
      }
 }
 </style>


### PR DESCRIPTION
To test

- create an Intel Referral form, include line breaks in the textarea as you're creating it
- generate a PDF for it
- your PDF should preserve those line breaks
- the rest of the PDF should remain the same


- create any other form
- generate a PDF for it
- this PDF design should not be broken

----

Notes on the code

- removed `page-break-inside: avoid` from `.govuk-textarea` as that was causing long textareas to break to the next page and leaving just the title on a page
- added `white-space: pre-wrap` to `.govuk-textarea div` to leave the title spacing as is (excess whitespace removed) and preserve the whitespace as entered by the user in the textarea